### PR TITLE
Patch 1

### DIFF
--- a/CyPolicies.ps1
+++ b/CyPolicies.ps1
@@ -41,16 +41,33 @@ function Set-CyPolicyForDevice {
         [object]$Policy
     )
 
-    Begin {
-        if ($null -eq $Policy.policy_id) {
-            throw "Policy object does not contain 'policy_id' property."
-        }
-    }
+    Begin
+	{
+		if (([string]::IsNullOrEmpty($Policy.policy_id)) -and ([string]::IsNullOrEmpty($Policy.id)))
+		{
+			throw "Policy object does not contain 'policy_id' or 'id' property."
+		}
+		if (([string]::IsNullOrEmpty($Policy.policy_id)) -and (![string]::IsNullOrEmpty($Policy.id)))
+		{
+			#ok
+		}
+		if (!([string]::IsNullOrEmpty($Policy.policy_id)) -and ([string]::IsNullOrEmpty($Policy.id)))
+		{
+			$Policy | Add-Member -Name id -Value $Policy.policy_id -MemberType NoteProperty
+		}
+		if (!([string]::IsNullOrEmpty($Policy.policy_id)) -and (!([string]::IsNullOrEmpty($Policy.id))))
+		{
+			if(($Policy.policy_id).tostring() -ne ($Policy.id).tostring())
+			{
+				throw 'Different value found in policy_id and id, expected to be the same'
+			}
+		}
+	}
 
     Process {
         $updateMap = @{
             "name" = $($Device.name)
-            "policy_id" = $($Policy.policy_id)
+            "policy_id" = $($Policy.id)
         }
 
         $json = $updateMap | ConvertTo-Json

--- a/CyPolicies.ps1
+++ b/CyPolicies.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Gets a list of all policies from the console.
 
@@ -49,17 +49,21 @@ function Set-CyPolicyForDevice {
 		}
 		if (([string]::IsNullOrEmpty($Policy.policy_id)) -and (![string]::IsNullOrEmpty($Policy.id)))
 		{
-			#ok
+			 $PolicyID = $policy.id
 		}
 		if (!([string]::IsNullOrEmpty($Policy.policy_id)) -and ([string]::IsNullOrEmpty($Policy.id)))
 		{
-			$Policy | Add-Member -Name id -Value $Policy.policy_id -MemberType NoteProperty
+			 $PolicyID = $Policy.policy_id
 		}
 		if (!([string]::IsNullOrEmpty($Policy.policy_id)) -and (!([string]::IsNullOrEmpty($Policy.id))))
 		{
-			if(($Policy.policy_id).tostring() -ne ($Policy.id).tostring())
+			if(($Policy.policy_id).tostring() -eq ($Policy.id).tostring())
 			{
-				throw 'Different value found in policy_id and id, expected to be the same'
+			$PolicyID = $policy.id
+			}
+			else
+			{
+			throw 'Different value found in policy_id and id, expected to be the same'	
 			}
 		}
 	}
@@ -67,7 +71,7 @@ function Set-CyPolicyForDevice {
     Process {
         $updateMap = @{
             "name" = $($Device.name)
-            "policy_id" = $($Policy.id)
+            "policy_id" = $PolicyID
         }
 
         $json = $updateMap | ConvertTo-Json

--- a/CyPolicies.ps1
+++ b/CyPolicies.ps1
@@ -50,7 +50,7 @@ function Set-CyPolicyForDevice {
     Process {
         $updateMap = @{
             "name" = $($Device.name)
-            "policy_id" = $($Policy.id)
+            "policy_id" = $($Policy.policy_id)
         }
 
         $json = $updateMap | ConvertTo-Json

--- a/CyPolicies.ps1
+++ b/CyPolicies.ps1
@@ -42,8 +42,8 @@ function Set-CyPolicyForDevice {
     )
 
     Begin {
-        if ($null -eq $Policy.id) {
-            throw "Policy object does not contain 'id' property."
+        if ($null -eq $Policy.policy_id) {
+            throw "Policy object does not contain 'policy_id' property."
         }
     }
 


### PR DESCRIPTION
When using 'get-cypolicy' the object resturen policy_id instead of id.
To workaround this issue, we can add the id property:
$PolicyObject | Add-Member -Name id -Value $PolicyObject.policy_id -MemberType NoteProperty

- Or change the  Set-CyPolicyForDevice to expect a policy_id